### PR TITLE
Auto-fail over to cloud when a local connection is connected but unresponsive (fixes Qrevo / a185)

### DIFF
--- a/roborockLib/lib/messageQueueHandler.js
+++ b/roborockLib/lib/messageQueueHandler.js
@@ -21,6 +21,14 @@ class messageQueueHandler {
 			this.adapter.log.info(`Local connection unavailable for ${duid}. Falling back to cloud connection for method ${method}.`);
 		}
 
+		// Some devices (e.g. the Qrevo / roborock.vacuum.a185) keep the local socket
+		// connected but never answer, so the disconnect-based fallback above never
+		// triggers. After repeated local timeouts, prefer cloud for a cooldown window.
+		if (!useCloudConnection && mqttConnectionState && typeof this.adapter.shouldPreferCloudLocally === "function" && this.adapter.shouldPreferCloudLocally(duid)) {
+			useCloudConnection = true;
+			this.adapter.log.info(`Local connection for ${duid} is unresponsive. Falling back to cloud connection for method ${method}.`);
+		}
+
 		if (!useCloudConnection && version == "L01") {
 			try {
 				await this.adapter.localConnector.ensureL01Handshake(duid);
@@ -64,6 +72,9 @@ class messageQueueHandler {
 						if (useCloudConnection) {
 							reject(new Error(`Cloud request with id ${messageID} with method ${method} timed out after 10 seconds. MQTT connection state: ${mqttConnectionState}`));
 						} else {
+							if (typeof this.adapter.recordLocalTimeout === "function") {
+								this.adapter.recordLocalTimeout(duid);
+							}
 							reject(new Error(`Local request with id ${messageID} with method ${method} timed out after 10 seconds Local connect state: ${localConnectionState}`));
 						}
 					}, requestTimeout);
@@ -72,6 +83,9 @@ class messageQueueHandler {
 					const trackedResolve = (value) => {
 						if (typeof this.adapter.recordMethodSuccess === "function") {
 							this.adapter.recordMethodSuccess(duid, method);
+						}
+						if (!useCloudConnection && typeof this.adapter.recordLocalSuccess === "function") {
+							this.adapter.recordLocalSuccess(duid);
 						}
 						resolve(value);
 					};

--- a/roborockLib/roborockAPI.js
+++ b/roborockLib/roborockAPI.js
@@ -84,6 +84,15 @@ class Roborock {
     this.methodBackoffThreshold = 3; // consecutive timeouts before backing off
     this.methodBackoffInterval = 30 * 60 * 1000; // 30 min before a retry
 
+    // Some newer models (e.g. the Qrevo / roborock.vacuum.a185) keep the local TCP
+    // connection open but never answer, so every local request times out. Track
+    // consecutive local timeouts per device and, once over the threshold, prefer the
+    // cloud path for a cooldown window (retrying local afterwards). Keyed by duid.
+    this.localTimeoutStreak = new Map();
+    this.localCloudPreference = new Map();
+    this.localFailoverThreshold = 3; // consecutive local timeouts before preferring cloud
+    this.localFailoverInterval = 5 * 60 * 1000; // 5 min preferring cloud before retrying local
+
     this.localDevices = {};
     this.remoteDevices = new Set();
 
@@ -1913,6 +1922,45 @@ class Roborock {
   shouldPollMethod(duid, method) {
     const until = this.methodPollBackoff.get(`${duid}:${method}`);
     return !until || Date.now() >= until;
+  }
+
+  // Called by the message queue when a LOCAL request times out. After a few
+  // consecutive local timeouts we treat the device's local connection as
+  // unresponsive (connected but mute) and prefer the cloud path for a cooldown.
+  recordLocalTimeout(duid) {
+    if (!duid) {
+      return;
+    }
+
+    const streak = (this.localTimeoutStreak.get(duid) || 0) + 1;
+
+    if (streak >= this.localFailoverThreshold) {
+      this.localCloudPreference.set(duid, Date.now() + this.localFailoverInterval);
+      this.localTimeoutStreak.set(duid, 0);
+      this.log.info(
+        `Local connection for ${duid} is unresponsive after ${streak} consecutive timeouts; preferring cloud for ${Math.round(this.localFailoverInterval / 60000)} min.`
+      );
+    } else {
+      this.localTimeoutStreak.set(duid, streak);
+    }
+  }
+
+  // Called by the message queue when a LOCAL request succeeds. Clears any local
+  // failover state so a recovered local connection is used again.
+  recordLocalSuccess(duid) {
+    if (!duid) {
+      return;
+    }
+
+    this.localTimeoutStreak.delete(duid);
+    this.localCloudPreference.delete(duid);
+  }
+
+  // Whether requests for a device should prefer the cloud path because its local
+  // connection is connected but unresponsive (true during the failover cooldown).
+  shouldPreferCloudLocally(duid) {
+    const until = this.localCloudPreference.get(duid);
+    return !!until && Date.now() < until;
   }
 
   // Poll a method that a device may not support. A device that never answers


### PR DESCRIPTION
## Problem

On newer models like the Roborock **Qrevo** (`roborock.vacuum.a185`), the device accepts the local TCP connection but never answers the local control protocol, so every local request times out (10s each). The existing fallback only switches to the cloud/MQTT path when the local socket is *disconnected* — but here it stays "connected yet mute", so it never falls back and remains on the dead local path. Cloud/MQTT works fine for these models.

## Root cause

`messageQueueHandler.sendRequest` only sets `useCloudConnection` on `!localConnectionState`, and `localConnector.isConnected()` returns the socket's `connected` flag, which stays `true` for a TCP-accepted-but-silent peer — so the disconnect-based fallback never triggers.

## Fix

An automatic, self-healing local→cloud failover modeled on the existing `recordMethodTimeout` / `methodPollBackoff` mechanism:

- **`roborockAPI.js`**: device-keyed `recordLocalTimeout` / `recordLocalSuccess` / `shouldPreferCloudLocally`, alongside the existing per-method backoff maps. After N consecutive local timeouts for a device, prefer the cloud path for a cooldown window; a successful local response clears the state and reverts to local.
- **`messageQueueHandler.js`**: consults `shouldPreferCloudLocally` when choosing the transport, and records local timeouts/successes — guarded with `typeof` checks, exactly like the existing `recordMethodTimeout`/`recordMethodSuccess` calls.

## Behavior

Healthy local devices never trip (a successful local response resets the streak). Mute-but-connected devices move to cloud within ~one poll cycle and revert automatically if local ever recovers. No config, schema, or breaking changes.

## Why not alternatives

- A config flag would need cross-language schema + `src/` plumbing and would penalize healthy local devices.
- A hardcoded `a185` allowlist (like the existing `version == "L01"` special-case) wouldn't cover other newer models hitting the same wall.

This generic failover covers a185 and any future model with the same behavior.

## Testing

Verified live on an a185 that preferring the cloud path makes the device work, and that the failover trips and reverts as designed. I wasn't able to run the Jest suite in my environment — the change is additive and `typeof`-guarded, so it no-ops if the adapter methods are absent. Matched each file's existing indentation in the vendored `roborockLib`.
