### PR TITLE
feat: publish current cleaning room to MQTT (opt-in telemetry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,42 @@ Follow these steps to install the plugin:
 Use the Homebridge UI settings page to sign in and configure the plugin. To exclude vacuums from HomeKit, add their Roborock device IDs to **Skipped Device IDs**.
 
 When Homebridge restarts, matching devices will be skipped during discovery. If a skipped device already exists in HomeKit as a cached accessory, the plugin will remove it from Homebridge.
+
+## Current Room → MQTT (optional telemetry)
+
+The plugin can publish the room a vacuum is currently cleaning to a local MQTT broker, for use in external automations (e.g. lighting that follows the vacuum room to room). This is **telemetry only** — it is not exposed to HomeKit — and is **off by default**. It reuses the `mqtt` dependency the plugin already ships, so it adds nothing when disabled.
+
+Enable it under **Current Room → MQTT** in the settings UI, or in `config.json`:
+
+```json
+"currentRoomMqtt": {
+  "enabled": true,
+  "brokerUrl": "mqtt://127.0.0.1:1883",
+  "topic": "homebridge/roborock/{duid}/current_room",
+  "cleaningPollSeconds": 10
+}
+```
+
+- **topic** is a template. `{duid}` and `{name}` (the device name, slugified) are substituted. If the template contains neither token, `/{duid}` is appended automatically so multiple vacuums never publish to the same topic.
+- **cleaningPollSeconds** is how often status is polled while the vacuum is actively cleaning (it polls slowly otherwise). The poll only runs while the feature is enabled.
+
+A retained JSON message is published whenever the room changes:
+
+```json
+{
+  "segment_id": 16,
+  "room": "Kitchen",
+  "state": 5,
+  "target_segment_id": 17,
+  "target_room": "Hallway",
+  "in_cleaning": 1,
+  "ts": 1718524800000
+}
+```
+
+- **segment_id / room** — the room currently being cleaned. `segment_id` is `-1` (and `room` `null`) when docked/idle, or transiently while the robot relocalizes; use `state` to distinguish.
+- **target_segment_id / target_room** — the next room the robot is heading to (populated during transitions), so a consumer can pre-light it. `-1`/`null` when steady or unknown.
+- **in_cleaning** — the device's own flag; `0` once a clean has concluded even while the robot returns to the dock or empties, which `state` alone does not always distinguish.
+- Room names are resolved from the robot's saved map; name your rooms in the Roborock app for them to appear.
+
+> Validated on a Roborock Qrevo (`roborock.vacuum.a185`). On models that don't populate `cleaning_info`, the payload degrades gracefully to `segment_id: -1` / `room: null`.

--- a/config.schema.json
+++ b/config.schema.json
@@ -40,6 +40,38 @@
         "description": "When enabled, debug messages will be written to the log.",
         "type": "boolean",
         "default": false
+      },
+      "currentRoomMqtt": {
+        "title": "Current Room → MQTT",
+        "type": "object",
+        "description": "Publish the room each vacuum is currently cleaning to a local MQTT broker (telemetry only; not exposed to HomeKit). Off by default.",
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean",
+            "default": false,
+            "description": "Publish the current cleaning room to MQTT."
+          },
+          "brokerUrl": {
+            "title": "Broker URL",
+            "type": "string",
+            "default": "mqtt://127.0.0.1:1883",
+            "description": "MQTT broker URL."
+          },
+          "topic": {
+            "title": "Topic Template",
+            "type": "string",
+            "default": "homebridge/roborock/{duid}/current_room",
+            "description": "Topic to publish the retained current-room JSON to. Supports {duid} and {name} tokens; if neither is present, /{duid} is appended automatically so multiple vacuums don't collide."
+          },
+          "cleaningPollSeconds": {
+            "title": "Cleaning Poll Interval (s)",
+            "type": "integer",
+            "default": 10,
+            "minimum": 5,
+            "description": "How often to poll status while actively cleaning, to catch room changes."
+          }
+        }
       }
     },
     "required": ["email"]

--- a/roborockLib/lib/vacuum.js
+++ b/roborockLib/lib/vacuum.js
@@ -162,6 +162,38 @@ class vacuum {
 				const now = new Date();
 				const seconds = now.getSeconds();
 
+				// current-room -> MQTT (opt-in telemetry): a dedicated lightweight poll,
+				// independent of the legacy branch below. That branch is gated on
+				// `this.adapter.socket` (a live web-UI client) OR an undefined
+				// `config.updateInterval` (=> NaN, never true), so it does not run in
+				// normal headless operation and can't be relied on to publish. Polls fast
+				// while cleaning, idle otherwise; serialized by `_roomPollInFlight`; never
+				// runs when the feature is disabled, so default behaviour is unchanged.
+				const roomMqttCfg = this.adapter.config && this.adapter.config.currentRoomMqtt;
+				if (roomMqttCfg && roomMqttCfg.enabled) {
+					const vac = this.adapter.vacuums[duid];
+					const idleInterval = this.adapter.updateInterval || 180;
+					const fastInterval = roomMqttCfg.cleaningPollSeconds || 10;
+					const interval = vac && vac._lastIsCleaning ? Math.min(fastInterval, idleInterval) : idleInterval;
+					if (seconds % interval == 0 && !(vac && vac._roomPollInFlight)) {
+						if (vac) vac._roomPollInFlight = true;
+						try {
+							const ds = await this.adapter.messageQueueHandler.sendRequest(duid, "get_prop", ["get_status"]);
+							const s0 = (ds && ds[0]) || {};
+							if (vac) vac._lastIsCleaning = this.adapter.isCleaning(s0["state"]);
+							this.adapter.publishCurrentRoom(duid, {
+								cleaningInfo: s0["cleaning_info"],
+								state: s0["state"],
+								inCleaning: s0["in_cleaning"],
+							});
+						} catch (e) {
+							this.adapter.log.debug(`current_room poll failed: ${e && e.message}`);
+						} finally {
+							if (vac) vac._roomPollInFlight = false;
+						}
+					}
+				}
+
 				if (this.adapter.socket || seconds % this.adapter.config.updateInterval == 0) {
 					// only send status every minute or if websocket is connected
 
@@ -257,6 +289,9 @@ class vacuum {
 
 						if (roomName) {
 							this.adapter.log.debug(`Mapped room matched: ${roomID} with name: ${roomName}`);
+							// current-room -> MQTT: cache segment_id -> name for the publisher.
+							if (!this.adapter.segmentRoomNames[duid]) this.adapter.segmentRoomNames[duid] = {};
+							this.adapter.segmentRoomNames[duid][mappedRoom[0]] = roomName;
 							const objectString = `Devices.${duid}.floors.${roomFloor}.${mappedRoom[0]}`;
 							await this.adapter.createStateObjectHelper(objectString, roomName, "boolean", null, true, "value", true, true);
 						}

--- a/roborockLib/roborockAPI.js
+++ b/roborockLib/roborockAPI.js
@@ -21,6 +21,7 @@ const roborockPackageHelper =
 const deviceFeatures = require("./lib/deviceFeatures").deviceFeatures;
 const messageQueueHandler =
   require("./lib/messageQueueHandler").messageQueueHandler;
+const mqtt = require("mqtt");
 
 let socketServer, webserver;
 
@@ -50,6 +51,12 @@ class Roborock {
     this.localKeys = null;
     this.localL01Nonces = new Map();
     this.roomIDs = {};
+    // current-room -> MQTT (opt-in telemetry): per-duid segment_id -> room name
+    // cache, a lazily-opened local publisher client, and the last-published
+    // dedupe key per duid. All inert unless config.currentRoomMqtt.enabled.
+    this.segmentRoomNames = {};
+    this.localMqttClient = null;
+    this._lastRoomPublishKey = {};
     this.vacuums = {};
     this.initializedVacuumDuids = new Set();
     this.socket = null;
@@ -1277,6 +1284,16 @@ class Roborock {
       this.clearInterval(this.vacuums[duid].mainUpdateInterval);
     }
 
+    // current-room -> MQTT: tear down the local publisher client.
+    if (this.localMqttClient) {
+      try {
+        this.localMqttClient.end(true);
+      } catch (e) {
+        /* ignore */
+      }
+      this.localMqttClient = null;
+    }
+
     this.messageQueue.forEach(({ timeout102, timeout301 }) => {
       this.clearTimeout(timeout102);
       if (timeout301) {
@@ -1770,6 +1787,117 @@ class Roborock {
         return true;
       default:
         return false;
+    }
+  }
+
+  // current-room -> MQTT: lazily open a LOCAL mqtt publisher (separate from the
+  // Roborock cloud connection). Telemetry only — it never subscribes. Never
+  // throws; a down broker only logs at debug and retries via reconnectPeriod.
+  ensureLocalMqtt() {
+    const cfg = this.config && this.config.currentRoomMqtt;
+    if (!cfg || !cfg.enabled) return null;
+    if (this.localMqttClient) return this.localMqttClient;
+
+    try {
+      const url = cfg.brokerUrl || "mqtt://127.0.0.1:1883";
+      const client = mqtt.connect(url, {
+        reconnectPeriod: 5000,
+        connectTimeout: 10000,
+      });
+      client.on("error", (e) =>
+        this.log.debug(`current_room MQTT error: ${e && e.message}`)
+      );
+      client.on("connect", () =>
+        this.log.debug(`current_room MQTT connected to ${url}`)
+      );
+      // After a reconnect, drop the dedupe cache so the (retained) current room
+      // is re-published — a broker bounce may have lost the retained message.
+      client.on("reconnect", () => {
+        this._lastRoomPublishKey = {};
+      });
+      this.localMqttClient = client;
+    } catch (e) {
+      this.log.debug(`current_room MQTT connect failed: ${e && e.message}`);
+      this.localMqttClient = null;
+    }
+    return this.localMqttClient;
+  }
+
+  // current-room -> MQTT: resolve the publish topic for a device. The configured
+  // topic is a template: {duid} and {name} tokens are substituted; if it contains
+  // no token, /{duid} is appended so multiple vacuums never collide on one topic.
+  resolveRoomTopic(duid) {
+    const cfg = this.config && this.config.currentRoomMqtt;
+    let topic = (cfg && cfg.topic) || "homebridge/roborock/{duid}/current_room";
+    const hasToken = topic.includes("{duid}") || topic.includes("{name}");
+    if (!hasToken) {
+      topic = `${topic.replace(/\/+$/, "")}/${duid}`;
+    }
+    const rawName = (this.vacuums[duid] && this.vacuums[duid].name) || duid;
+    const slug = String(rawName)
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "");
+    // Fall back to duid if the name slugifies to empty (e.g. a symbol-only name),
+    // so a {name}-only template can never collide or produce a malformed topic.
+    const name = slug || duid;
+    return topic.replace(/\{duid\}/g, duid).replace(/\{name\}/g, name);
+  }
+
+  // current-room -> MQTT: publish the room a vacuum is currently cleaning.
+  // segment_id comes from get_status.cleaning_info; the name is resolved from the
+  // segmentRoomNames cache (populated by the get_room_mapping handler). -1 means
+  // docked/idle or, when state indicates motion, relocalizing. target_* expose the
+  // next room (cleaning_info.target_segment_id populates during transitions) so a
+  // consumer can pre-light it; in_cleaning is the device flag (0 once a clean
+  // concludes, even while it returns/empties). Fire-and-forget; never rejects.
+  publishCurrentRoom(duid, raw) {
+    try {
+      const cfg = this.config && this.config.currentRoomMqtt;
+      if (!cfg || !cfg.enabled) return;
+      const client = this.ensureLocalMqtt();
+      if (!client || !client.connected) return;
+
+      const ci = raw && raw.cleaningInfo;
+      const segId =
+        ci && typeof ci.segment_id === "number" ? ci.segment_id : -1;
+      const room =
+        segId >= 0 ? this.segmentRoomNames?.[duid]?.[segId] ?? null : null;
+      const tSegId =
+        ci && typeof ci.target_segment_id === "number"
+          ? ci.target_segment_id
+          : -1;
+      const targetRoom =
+        tSegId >= 0 ? this.segmentRoomNames?.[duid]?.[tSegId] ?? null : null;
+      const state = typeof raw.state === "number" ? raw.state : null;
+      const inCleaning =
+        typeof raw.inCleaning === "number" ? raw.inCleaning : null;
+
+      // target_segment_id and in_cleaning MUST be in the dedupe key: they change
+      // while segment_id/state may not, so without them those transitions (e.g. a
+      // target flip -1 -> N -> -1) would be deduped away.
+      const key = `${segId}|${room}|${state}|${tSegId}|${targetRoom}|${inCleaning}`;
+      if (key === this._lastRoomPublishKey[duid]) return; // dedupe (ts excluded)
+      this._lastRoomPublishKey[duid] = key;
+
+      const topic = this.resolveRoomTopic(duid);
+      const payload = JSON.stringify({
+        segment_id: segId,
+        room,
+        state,
+        target_segment_id: tSegId,
+        target_room: targetRoom,
+        in_cleaning: inCleaning,
+        ts: Date.now(),
+      });
+      client.publish(topic, payload, { retain: true, qos: 0 }, (err) => {
+        if (err) {
+          this.log.debug(`current_room MQTT publish failed: ${err.message}`);
+          this._lastRoomPublishKey[duid] = undefined; // allow retry on next change
+        }
+      });
+    } catch (e) {
+      this.log.debug(`publishCurrentRoom error: ${e && e.message}`);
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -127,6 +127,7 @@ export default class RoborockPlatform implements DynamicPlatformPlugin {
       log: this.log,
       userData: decryptedSession,
       storagePath: storagePath,
+      currentRoomMqtt: this.platformConfig.currentRoomMqtt,
     });
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,4 +7,10 @@ export interface RoborockPlatformConfig extends PlatformConfig {
   baseURL?: string;
   encryptedToken?: string;
   skipDevices?: string | string[];
+  currentRoomMqtt?: {
+    enabled?: boolean;
+    brokerUrl?: string;
+    topic?: string;
+    cleaningPollSeconds?: number;
+  };
 }


### PR DESCRIPTION
Adds an optional, off-by-default feature to publish the room each vacuum is currently cleaning to a local MQTT broker — useful for external automations (e.g. lighting that follows the vacuum room to room). **Telemetry only** (not exposed to HomeKit).

**Behavior when disabled (the default):** no network activity, no new timer, no MQTT client — a single property read per status tick. Zero change for existing users.

**When enabled** (`currentRoomMqtt.enabled`), a feature-gated poll publishes a retained JSON payload on each room change:
```json
{ "segment_id": 16, "room": "Kitchen", "state": 5,
  "target_segment_id": 17, "target_room": "Hallway",
  "in_cleaning": 1, "ts": 1718524800000 }
```
- **Multi-device safe:** the `topic` is a template (`{duid}`/`{name}` tokens; `/{duid}` auto-appended when no token present) so multiple vacuums never collide. Default `homebridge/roborock/{duid}/current_room`.
- Reuses the existing `mqtt` dependency; the local client is **publisher-only** (never subscribes) and torn down in `clearTimersAndIntervals`.
- Room names resolve from the saved map (`get_room_mapping`).

**Notes:**
- The poll is intentionally independent of the legacy `get_status` branch (which only runs when the web-UI socket is connected) and is serialized by an in-flight guard.
- Validated on a Roborock Qrevo (`a185`); degrades gracefully to `segment_id: -1` / `room: null` on models that don't populate `cleaning_info`.
- The pre-existing `npm test` failure (constructor reads `this.api.hap` in a field initializer) is reproducible on `master` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
