### PR TITLE
fix(L01): send correct 21-byte HELLO frame so L01 devices connect locally

### DIFF
--- a/roborockLib/lib/localConnector.js
+++ b/roborockLib/lib/localConnector.js
@@ -111,9 +111,12 @@ class localConnector {
 					while (offset + 4 <= client.chunkBuffer.length) {
 						const segmentLength = client.chunkBuffer.readUInt32BE(offset);
 						const currentBuffer = client.chunkBuffer.subarray(offset + 4, offset + segmentLength + 4);
-						// length of 17 does not contain any useful data.
-						// It seems to be protocol handshake metadata.
-						if (segmentLength != 17) {
+						// Short, header-only handshake frames carry no encrypted payload:
+						// the L01 HELLO_RESPONSE is 21 bytes (version+seq+random+timestamp+
+						// protocol+CRC32); a bare 17-byte header may also appear. Route both
+						// to the shortMessage handler below; anything larger is a data
+						// message with an encrypted payload.
+						if (segmentLength != 17 && segmentLength != 21) {
 							const data = this.adapter.message._decodeMsg(currentBuffer, duid);
 							if (!data) {
 								offset += 4 + segmentLength;
@@ -146,7 +149,9 @@ class localConnector {
 						else {
 							try {
 								const shortMessage = shortMessageParser.parse(currentBuffer);
-								if (shortMessage.version == "L01" && shortMessage.protocol == 1) {
+								// HELLO_RESPONSE (protocol 1) echoing our seq=1 HELLO; its
+								// random field is the ack_nonce.
+								if (shortMessage.version == "L01" && shortMessage.protocol == 1 && shortMessage.seq == 1) {
 									const currentNonces = this.adapter.localL01Nonces.get(duid) || {};
 									this.adapter.localL01Nonces.set(duid, {
 										connectNonce: currentNonces.connectNonce,
@@ -157,6 +162,7 @@ class localConnector {
 									if (waiter) {
 										this.adapter.clearTimeout(waiter.timeout);
 										this.l01HandshakeWaiters.delete(duid);
+										this.adapter.log.debug(`L01 handshake complete for ${duid}: ackNonce=${shortMessage.random}`);
 										waiter.resolve(true);
 									}
 								}
@@ -247,17 +253,28 @@ class localConnector {
 			return;
 		}
 
+		// HELLO request: protocol 0 (HELLO_REQUEST), 21-byte header+CRC frame, seq=1, a
+		// real timestamp, and random=connect_nonce. The robot replies with a protocol-1
+		// (HELLO_RESPONSE) frame whose random field is the ack_nonce. Pick a stable
+		// connect_nonce in [10000, 32767] and store it BEFORE sending, so the follow-up
+		// L01 data-message AAD reuses the exact value the robot saw in the HELLO.
 		const timestamp = Math.floor(Date.now() / 1000);
-		const handshakeMessage = await this.adapter.message.buildRoborockMessage(duid, 1, timestamp, Buffer.alloc(0));
-		if (!handshakeMessage) {
-			throw new Error(`Failed to build protocol 1 handshake message for ${duid}`);
-		}
-
-		const connectNonce = handshakeMessage.readUInt32BE(7);
+		const connectNonce = 10000 + Math.floor(Math.random() * 22768);
 		this.adapter.localL01Nonces.set(duid, {
 			connectNonce,
 			ackNonce: undefined,
 		});
+
+		const handshakeMessage = await this.adapter.message.buildRoborockMessage(
+			duid,
+			0,
+			timestamp,
+			Buffer.alloc(0),
+			{ seq: 1, random: connectNonce }
+		);
+		if (!handshakeMessage) {
+			throw new Error(`Failed to build HELLO handshake message for ${duid}`);
+		}
 
 		if (this.l01HandshakeWaiters.has(duid)) {
 			const waiter = this.l01HandshakeWaiters.get(duid);

--- a/roborockLib/lib/message.js
+++ b/roborockLib/lib/message.js
@@ -123,7 +123,7 @@ class message {
     return payload;
   }
 
-  async buildRoborockMessage(duid, protocol, timestamp, payload) {
+  async buildRoborockMessage(duid, protocol, timestamp, payload, options = {}) {
     const version = await this.adapter.getRobotVersion(duid);
 
     let encrypted;
@@ -131,18 +131,29 @@ class message {
     const currentSeq = seq & 0xffffffff;
     const currentRandom = random & 0xffffffff;
 
-    if (protocol == 1) {
-      const msg = Buffer.alloc(23);
+    // Header-only frames (the L01 HELLO request, protocol 0) carry no encrypted
+    // payload, so they have NO payloadLen field — just version(3) + seq(4) + random(4)
+    // + timestamp(4) + protocol(2) + CRC32(4) = 21 bytes. (The previous build emitted a
+    // 23-byte frame with a spurious payloadLen, which L01 robots silently drop, so the
+    // handshake never completed.) Optional explicit seq/random let the HELLO pin seq=1
+    // and a stable connect_nonce without disturbing the module-global counters used by
+    // data messages.
+    if (protocol == 0 || protocol == 1) {
+      const headerSeq = (options.seq !== undefined ? options.seq : currentSeq) >>> 0;
+      const headerRandom =
+        (options.random !== undefined ? options.random : currentRandom) >>> 0;
+      const msg = Buffer.alloc(21);
       msg.write(version);
-      msg.writeUint32BE(currentSeq, 3);
-      msg.writeUint32BE(currentRandom, 7);
+      msg.writeUint32BE(headerSeq, 3);
+      msg.writeUint32BE(headerRandom, 7);
       msg.writeUint32BE(timestamp, 11);
       msg.writeUint16BE(protocol, 15);
-      msg.writeUint16BE(0, 17);
-      const crc32 = CRC32.buf(msg.subarray(0, msg.length - 4)) >>> 0;
-      msg.writeUint32BE(crc32, msg.length - 4);
-      seq++;
-      random++;
+      const crc32 = CRC32.buf(msg.subarray(0, 17)) >>> 0;
+      msg.writeUint32BE(crc32, 17);
+      if (options.seq === undefined) {
+        seq++;
+        random++;
+      }
 
       return msg;
     }


### PR DESCRIPTION
## Problem

Newer Roborock models that use the **L01** local transport (AES‑256‑GCM behind a protocol‑0 HELLO handshake on TCP `58867`) never actually establish a local connection. The socket connects, but every local RPC times out with `Local connect state: true` and the plugin falls back to cloud for everything:

```
Local request with id N with method get_status timed out after 10 seconds Local connect state: true
Local connection unavailable ... Falling back to cloud connection for method get_status.
```

Reported in #45 (Saros 10 / `a147`) and #31 (Q7 Max), among others.

## Root cause

The L01 handshake added in `6d50ebf5` builds a **malformed HELLO frame**. `ensureL01Handshake()` calls `buildRoborockMessage(duid, 1, …)`, which emits a frame that includes a `payloadLen` field **and** a CRC (23 bytes), then prepends a length prefix. The real L01 HELLO is **21 bytes**:

```
version(3) + seq(4) + random(4) + timestamp(4) + protocol(2) + CRC32(4)
```

— a CRC but **no `payloadLen` field** — sent as protocol `0` (`HELLO_REQUEST`). The robot silently drops the malformed frame, so the handshake never completes.

Separately, the genuine `HELLO_RESPONSE` is also a 21‑byte frame, but the inbound parser only treated 17‑byte segments as handshake messages — so even a correct response was routed into `_decodeMsg` (the `protocol==4` data path) and the `ackNonce` was never captured.

This is also why #53's cloud failover was needed: it masked a handshake that never worked. With the handshake fixed, L01 devices stay on the fast local path (the failover remains as a safety net).

## Fix

- **`buildRoborockMessage`**: emit the correct **21‑byte header‑only frame** for protocol `0`/`1` (CRC over the first 17 bytes, no `payloadLen`). Optional `seq`/`random` let the HELLO pin `seq=1` and a stable `connect_nonce` without disturbing the module‑global counters used by data messages.
- **`ensureL01Handshake`**: send the HELLO as protocol `0` (`HELLO_REQUEST`) with `seq=1` and a `connect_nonce` in `[10000, 32767]`, stored before send.
- **inbound**: route 21‑byte (and 17‑byte) frames to the handshake handler and capture `ackNonce` from the `HELLO_RESPONSE`.

Two files, ~50 lines; no change to the cloud path or any other protocol.

## Verification

Confirmed **live against a real Roborock Qrevo (`roborock.vacuum.a185`)**: the handshake completes (`HELLO_RESPONSE` received, `ackNonce` captured) and local RPCs return real data instead of timing out — the `Falling back to cloud` spam disappears. The 21‑byte frame this code builds is byte‑identical to the frame the robot accepts, and the L01 GCM derivation was cross‑checked against the [`python-roborock`](https://github.com/Python-roborock/python-roborock) reference vectors.

## Scope / a note on `pv`

`Fixes #45`. Addresses #31. Should also help #20, #23, #38, #47 for L01‑transport models (some of those also involve a localKey/discovery stage, so confirmation from those reporters would be welcome — I didn't want to over‑claim).

One nuance worth flagging: the `a185` reports cloud `pv "1.0"` but speaks **L01** on the local socket, so it additionally needs its local protocol mapped to `L01` to *reach* this handshake (I handle that downstream with a small model check). Devices that already report `pv "L01"` are fixed by this change alone. I kept this PR to the protocol‑correctness fix to stay focused — happy to follow up on generalizing `pv → L01` detection (e.g. from the discovery broadcast or a model list) if you'd like it here too.
